### PR TITLE
windows bug fix

### DIFF
--- a/lib/google-maps/logger.rb
+++ b/lib/google-maps/logger.rb
@@ -11,7 +11,7 @@ module Google
       end
       
       def self.extended(base)
-        base.log_file = "/dev/null"
+        base.log_file = RUBY_PLATFORM.index(/mswin(?!ce)|mingw|cygwin|bccwin/) ? "nul" : "/dev/null"
       end
     end
   end


### PR DESCRIPTION
At "/dev/null", an error comes out by windows. 
In windows, it corrected so that it might be set to "nul". 
