### PR TITLE
Relax httpclient dependency to allow v2.8

### DIFF
--- a/google-maps.gemspec
+++ b/google-maps.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.7')
   s.add_dependency('json', '>= 1.7.5')
   s.add_dependency('hashie', '~> 2.0.5')
-  s.add_dependency('httpclient', '~> 2.7.1')
+  s.add_dependency('httpclient', '>= 2.7.1')
   s.add_dependency('ruby-hmac', '~> 0.4.0')
 end


### PR DESCRIPTION
The test suite passed locally for me using v2.8.3 and running my own app that depends on google-maps worked as expected after this change.

The big change in v2.8 seems to be a switch to using 2048 bit CA certificate set, not an API change (https://github.com/nahi/httpclient/blob/master/CHANGELOG.md#changes-in-280).

Thanks for this gem!