### PR TITLE
Fix Travis CI issue "undefined method `spec` for nil:NilClass"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm:
   - 2.1.5
   - 2.2.2
+before_install:
+  - gem install bundler


### PR DESCRIPTION
A newish verison of rubygems (v2.6.13) and an oldish version of bundler (v1.7.6) don't play well together, resulting in the above error when bundling.

Updating the version of bundler Travis CI provides to a newer version fixes this problem.

Here's some context of the problem: https://github.com/travis-ci/travis-ci/issues/3531