### PR TITLE
Add api key to Geocode API

### DIFF
--- a/lib/google-maps/location.rb
+++ b/lib/google-maps/location.rb
@@ -17,7 +17,16 @@ module Google
       end
 
       def self.find(address, language=:en)
-        API.query(:geocode_service, :language => language, :address => address).results.map { |result| Location.new(result.formatted_address, result.geometry.location.lat, result.geometry.location.lng) }
+        args = { language: language, address: address }
+        args[:key] = Google::Maps.api_key unless Google::Maps.api_key.nil?
+
+        API.query(:geocode_service, args).results.map do |result|
+          Location.new(
+            result.formatted_address,
+            result.geometry.location.lat,
+            result.geometry.location.lng,
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Google requires an API key for this API (source: https://developers.google.com/maps/documentation/geocoding/get-api-key) and you'll get "over query limit" errors early without it.

713e983e3bd77f8c30047b94959c9aec3133147d moved including the api key out of the generic API class and into the Place class only, but I'm not sure why. Perhaps geocoding didn't require an API key back then?