### PR TITLE
Retrieve all components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.2.2
   - 2.5.3
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/lib/google_maps/location.rb
+++ b/lib/google_maps/location.rb
@@ -5,13 +5,14 @@ require File.expand_path('api', __dir__)
 module Google
   module Maps
     class Location
-      attr_reader :address, :latitude, :longitude
+      attr_reader :address, :latitude, :longitude, :components
       alias to_s address
 
-      def initialize(address, latitude, longitude)
+      def initialize(address, latitude, longitude, components = {})
         @address = address
         @latitude = latitude
         @longitude = longitude
+        @components = components
       end
 
       def lat_lng
@@ -25,8 +26,23 @@ module Google
           Location.new(
             result.formatted_address,
             result.geometry.location.lat,
-            result.geometry.location.lng
+            result.geometry.location.lng,
+            format_components(result.address_components)
           )
+        end
+      end
+
+      def self.format_components(address_components)
+        address_components.each_with_object({}) do |v, acc|
+          types = v['types']
+          types.each do |t|
+            value = v['long_name']
+            if acc[t]
+              acc[t] << value
+            else
+              acc[t] = [value]
+            end
+          end
         end
       end
     end

--- a/lib/google_maps/location.rb
+++ b/lib/google_maps/location.rb
@@ -36,12 +36,8 @@ module Google
         address_components.each_with_object({}) do |v, acc|
           types = v['types']
           types.each do |t|
-            value = v['long_name']
-            if acc[t]
-              acc[t] << value
-            else
-              acc[t] = [value]
-            end
+            acc[t] ||= []
+            acc[t] << v['long_name']
           end
         end
       end

--- a/spec/google_maps_spec.rb
+++ b/spec/google_maps_spec.rb
@@ -68,7 +68,7 @@ describe Google::Maps do
       expect(components['postal_code']).to eq(['1098 XH'])
       expect(components['route']).to eq(['Science Park Amsterdam'])
       expect(components['street_number']).to eq(['400'])
-      expect(components['sublocality']).to eq(['Middenmeer', 'Watergraafsmeer'])
+      expect(components['sublocality']).to eq(%w[Middenmeer Watergraafsmeer])
     end
 
     it 'should handle multiple location for an address' do

--- a/spec/google_maps_spec.rb
+++ b/spec/google_maps_spec.rb
@@ -52,6 +52,25 @@ describe Google::Maps do
       expect(location.lat_lng).to eq([52.3564490, 4.95568890])
     end
 
+    it 'should extract all components for an address' do
+      stub_response('geocoder/science-park-400-amsterdam-en.json')
+
+      location = Google::Maps.geocode('Science Park 400, Amsterdam').first
+      components = location.components
+      expect(components['administrative_area_level_1']).to eq(['Noord-Holland'])
+      expect(components['administrative_area_level_2']).to eq(['Government of Amsterdam'])
+      expect(components['country']).to eq(['The Netherlands'])
+      expect(components['establishment']).to eq(['University of Amsterdam'])
+      expect(components['locality']).to eq(['Amsterdam'])
+      expect(components['political']).to eq(
+        ['Middenmeer', 'Watergraafsmeer', 'Amsterdam', 'Government of Amsterdam', 'Noord-Holland', 'The Netherlands']
+      )
+      expect(components['postal_code']).to eq(['1098 XH'])
+      expect(components['route']).to eq(['Science Park Amsterdam'])
+      expect(components['street_number']).to eq(['400'])
+      expect(components['sublocality']).to eq(['Middenmeer', 'Watergraafsmeer'])
+    end
+
     it 'should handle multiple location for an address' do
       stub_response('geocoder/amsterdam-en.json')
 


### PR DESCRIPTION
Google maps retrieve a lot of informations that might be useful. For instance one might need the country of a given result.

To allow that, I suggest we update the location class to include a components hash with all the elements retrieved from google-maps.