### PR TITLE
Bugfix for when DistanceMatrix recieves ZERO_RESULTS element status

### DIFF
--- a/lib/google_maps/distance_matrix.rb
+++ b/lib/google_maps/distance_matrix.rb
@@ -27,7 +27,7 @@ module Google
       def element
         element = distance_matrix.rows.first.elements.first
 
-        raise Google::Maps::ZeroResultsException if element.status == 'NOT_FOUND'
+        raise Google::Maps::ZeroResultsException if (element.status == 'NOT_FOUND' || element.status == 'ZERO_RESULTS')
 
         element
       end

--- a/spec/fixtures/distance-matrix-zero-results.json
+++ b/spec/fixtures/distance-matrix-zero-results.json
@@ -1,0 +1,14 @@
+{
+  "destination_addresses" : [ "Amsterdam" ],
+  "origin_addresses" : [ "Utrecht" ],
+  "rows" : [
+    {
+      "elements" : [
+        {
+          "status" : "ZERO_RESULTS"
+        }
+      ]
+    }
+  ],
+  "status" : "OK"
+}

--- a/spec/google_maps/distance_matrix_spec.rb
+++ b/spec/google_maps/distance_matrix_spec.rb
@@ -12,5 +12,16 @@ describe Google::Maps::DistanceMatrix do
       its(:distance) { should eq 53_744 }
       its(:duration) { should eq 3237 }
     end
+
+    context ':nl and zero results' do
+      before { stub_response('distance-matrix-zero-results.json') }
+
+      it 'raises Google::Maps::ZeroResultsException' do
+
+        expect { subject.distance }.to raise_error(Google::Maps::ZeroResultsException)
+        expect { subject.duration }.to raise_error(Google::Maps::ZeroResultsException)
+
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixing an issue where a NilClass property access occurs if ZERO_RESULTS is returned for distance matrix API call. I changed this so at least you can have a descriptive and rescue-able exception.