### PR TITLE
Show error message for ZeroResultsException and InvalidResponseException

### DIFF
--- a/lib/google_maps/api.rb
+++ b/lib/google_maps/api.rb
@@ -63,13 +63,13 @@ module Google
             Google::Maps.logger.error e.message.to_s
             raise InvalidResponseException, "unknown error: #{e.message}"
           end
-          handle_result_status(result.status)
+          handle_result_status(result.status, result.error_message)
           result
         end
 
-        def handle_result_status(status)
-          raise ZeroResultsException, "Google did not return any results: #{status}" if status == STATUS_ZERO_RESULTS
-          raise InvalidResponseException, "Google returned an error status: #{status}" if status != STATUS_OK
+        def handle_result_status(status, error_message)
+          raise ZeroResultsException, "#{status}: #{error_message}" if status == STATUS_ZERO_RESULTS
+          raise InvalidResponseException, "#{status}: #{error_message}" if status != STATUS_OK
         end
 
         def url_with_api_key(service, args = {})


### PR DESCRIPTION
Display the following error to the user:
```
[20] pry(main)> JSON.parse(HTTPClient.new.get_content(url))
=> {"error_message"=>"API keys with referer restrictions cannot be used with this API.",
 "results"=>[],
 "status"=>"REQUEST_DENIED"}
```
as
```
Google::Maps::InvalidResponseException: REQUEST_DENIED: API keys with referer restrictions cannot be used with this API.
```
instead of just 
```
Google::Maps::InvalidResponseException: Google returned an error status: REQUEST_DENIED
```