### PR TITLE
Add place_to to location result

### DIFF
--- a/lib/google_maps/location.rb
+++ b/lib/google_maps/location.rb
@@ -5,13 +5,14 @@ require File.expand_path('api', __dir__)
 module Google
   module Maps
     class Location
-      attr_reader :address, :latitude, :longitude, :components
+      attr_reader :address, :latitude, :longitude, :place_id, :components
       alias to_s address
 
-      def initialize(address, latitude, longitude, components = {})
+      def initialize(address, latitude, longitude, place_id, components = {})
         @address = address
         @latitude = latitude
         @longitude = longitude
+        @place_id = place_id
         @components = components
       end
 
@@ -27,6 +28,7 @@ module Google
             result.formatted_address,
             result.geometry.location.lat,
             result.geometry.location.lng,
+            result.place_id,
             format_components(result.address_components)
           )
         end

--- a/spec/fixtures/geocoder/amsterdam-en.json
+++ b/spec/fixtures/geocoder/amsterdam-en.json
@@ -104,6 +104,7 @@
           }
         }
       },
+      "place_id" : "ChIJVXealLU_xkcRja_At0z9AGY",
       "types" : [ "locality", "political" ]
     }
   ],

--- a/spec/fixtures/geocoder/science-park-400-amsterdam-en.json
+++ b/spec/fixtures/geocoder/science-park-400-amsterdam-en.json
@@ -71,6 +71,7 @@
           }
         }
       },
+      "place_id" : "ChIJIcrTFogJxkcRb0dbtBG4pQc",
       "types" : [ "street_address" ]
     }
   ],

--- a/spec/fixtures/geocoder/science-park-400-amsterdam-nl.json
+++ b/spec/fixtures/geocoder/science-park-400-amsterdam-nl.json
@@ -71,6 +71,7 @@
           }
         }
       },
+      "place_id" : "ChIJIcrTFogJxkcRb0dbtBG4pQc",
       "types" : [ "street_address" ]
     }
   ],

--- a/spec/google_maps_spec.rb
+++ b/spec/google_maps_spec.rb
@@ -69,6 +69,7 @@ describe Google::Maps do
       expect(components['route']).to eq(['Science Park Amsterdam'])
       expect(components['street_number']).to eq(['400'])
       expect(components['sublocality']).to eq(%w[Middenmeer Watergraafsmeer])
+      expect(location.place_id).to eq('ChIJIcrTFogJxkcRb0dbtBG4pQc')
     end
 
     it 'should handle multiple location for an address' do
@@ -80,6 +81,7 @@ describe Google::Maps do
       expect(location.address).to eq('Amsterdam, NY, USA')
       expect(location.latitude).to eq(42.93868560)
       expect(location.longitude).to eq(-74.18818580)
+      expect(location.place_id).to eq('ChIJVXealLU_xkcRja_At0z9AGY')
     end
 
     it 'should accept languages other than en' do
@@ -87,6 +89,13 @@ describe Google::Maps do
 
       location = Google::Maps.geocode('Science Park 400, Amsterdam', :nl).first
       expect(location.address).to eq('Science Park 400, Amsterdam, 1098 XH Amsterdam, Nederland')
+    end
+
+    it 'should return place_id' do
+      stub_response('geocoder/science-park-400-amsterdam-nl.json')
+
+      location = Google::Maps.geocode('Science Park 400, Amsterdam', :nl).first
+      expect(location.place_id).to eq('ChIJIcrTFogJxkcRb0dbtBG4pQc')
     end
 
     it 'should return an empty array when an address could not be geocoded' do


### PR DESCRIPTION
Added the `place_id` attribute to the `Location` class

```
location = Google::Maps.geocode('Science Park 400, Amsterdam').first
location.place_id
=> "ChIJIcrTFogJxkcRb0dbtBG4pQc"
```