### PR TITLE
Add short_name to formatted component

### DIFF
--- a/lib/google_maps/location.rb
+++ b/lib/google_maps/location.rb
@@ -38,6 +38,7 @@ module Google
           types.each do |t|
             acc[t] ||= []
             acc[t] << v['long_name']
+            acc[t] << v['short_name'] if v['short_name'] != v['long_name']
           end
         end
       end

--- a/spec/google_maps_spec.rb
+++ b/spec/google_maps_spec.rb
@@ -57,13 +57,13 @@ describe Google::Maps do
 
       location = Google::Maps.geocode('Science Park 400, Amsterdam').first
       components = location.components
-      expect(components['administrative_area_level_1']).to eq(['Noord-Holland'])
+      expect(components['administrative_area_level_1']).to eq(['Noord-Holland', 'NH'])
       expect(components['administrative_area_level_2']).to eq(['Government of Amsterdam'])
-      expect(components['country']).to eq(['The Netherlands'])
+      expect(components['country']).to eq(['The Netherlands', 'NL'])
       expect(components['establishment']).to eq(['University of Amsterdam'])
       expect(components['locality']).to eq(['Amsterdam'])
       expect(components['political']).to eq(
-        ['Middenmeer', 'Watergraafsmeer', 'Amsterdam', 'Government of Amsterdam', 'Noord-Holland', 'The Netherlands']
+        ['Middenmeer', 'Watergraafsmeer', 'Amsterdam', 'Government of Amsterdam', 'Noord-Holland', 'NH', 'The Netherlands', 'NL'],
       )
       expect(components['postal_code']).to eq(['1098 XH'])
       expect(components['route']).to eq(['Science Park Amsterdam'])


### PR DESCRIPTION
Add `short_name` to formatted component

```
location = Google::Maps.geocode('Science Park 400, Amsterdam').first

=> #<Google::Maps::Location:0x000055d0e4baa1e8 @address="Science Park 400, 1098 XH Amsterdam, Netherlands", @latitude=52.3563641, @longitude=4.955847299999999, @components={"street_number"=>["400"], "route"=>["Science Park"], "political"=>["Amsterdam-Oost", "Amsterdam", "Amsterdam", "Noord-Holland", "NH", "Netherlands", "NL"], "sublocality"=>["Amsterdam-Oost"], "sublocality_level_1"=>["Amsterdam-Oost"], "locality"=>["Amsterdam"], "administrative_area_level_2"=>["Amsterdam"], "administrative_area_level_1"=>["Noord-Holland", "NH"], "country"=>["Netherlands", "NL"], "postal_code"=>["1098 XH"]}>
```